### PR TITLE
add style zIndex to View when modal is not visible

### DIFF
--- a/index.js
+++ b/index.js
@@ -512,7 +512,7 @@ export default class ModalBox extends React.PureComponent {
       this.state.isAnimateOpen ||
       this.state.isAnimateClose;
 
-    if (!visible) return <View />;
+    if (!visible) return <View style={styles.transparent}/>;
 
     const content = (
       <View


### PR DESCRIPTION
# What is going on?
We got crash when having a multiple modal, then open the top modal a second time.

The crash error:
```
java.lang.ArrayIndexOutOfBoundsException: length=3; index=3
    at ...
```
**Level: {crash}**

# How to reproduce?
## Condition
- not using coverScreen props
- having a multiple modal shown

## Step
open the top modal, close it, and open it again

# Caused by
when the modal is not visible, the library will return only <View /> without zIndex props, and when it's visible, it'll return a view with a zIndex style props.

I'm not sure about the cause, but because the js side and native side is asynchronously connected, then maybe when the modal is about to be opened, the native side is trying to reOrder the view with zIndex (at com.facebook.react.uimanager.ViewGroupDrawingOrderHelper.getChildDrawingOrder) while the View with zIndex props is not ready yet. That's why we got `java.lang.ArrayIndexOutOfBoundsException: length=3; index=3`

# Resolved by
We return a `View` with the same zIndex (use styles.transparent) when the modal is not visible, in this way, the view group will have the same number of view with a zIndex props to prevent a `not ready` view whether it's visible or not.
